### PR TITLE
fix: fixed width responsive tables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skattlada",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skattlada",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "@googleapis/drive": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skattlada",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "private": true,
   "description": "Skattlåda File Sharing Server",
   "main": "server.js",

--- a/views/profile.handlebars
+++ b/views/profile.handlebars
@@ -60,30 +60,32 @@
           <div class="col text-center">
             <h3>Passkeys</h3>
 
-            <table class="table table-striped table-responsive-sm table-sm">
-              <tr>
-                <th scope="col">type</th>
-                <th scope="col">created</th>
-                <th scope="col"></th>
-              </tr>
-              <tr>
-                <td>{{profile.activePasskey.type}}</td>
-                <td>{{profile.activePasskey.created}}</td>
-                <td>
-                  (active)
-                </td>
-              </tr>
-              {{#each profile.otherPasskeys}}
-              <tr>
-                <td>{{type}}</td>
-                <td>{{created}}</td>
-                <td>
-                  <input type="hidden" name="cred_id" value="{{id}}">
-                  <button type="submit" class="btn btn-danger btn-sm passkeys_supported" name="action" value="delete_cred" hidden>forget</button>
-                </td>
-              </tr>
-              {{/each}}
-            </table>
+            <div class="container">
+              <table class="table table-striped table-responsive-sm table-sm">
+                <tr>
+                  <th scope="col">type</th>
+                  <th scope="col">created</th>
+                  <th scope="col"></th>
+                </tr>
+                <tr>
+                  <td>{{profile.activePasskey.type}}</td>
+                  <td>{{profile.activePasskey.created}}</td>
+                  <td>
+                    (active)
+                  </td>
+                </tr>
+                {{#each profile.otherPasskeys}}
+                <tr>
+                  <td>{{type}}</td>
+                  <td>{{created}}</td>
+                  <td>
+                    <input type="hidden" name="cred_id" value="{{id}}">
+                    <button type="submit" class="btn btn-danger btn-sm passkeys_supported" name="action" value="delete_cred" hidden>forget</button>
+                  </td>
+                </tr>
+                {{/each}}
+              </table>
+            </div>
           </div>
         </div>
 

--- a/views/shares.handlebars
+++ b/views/shares.handlebars
@@ -21,22 +21,24 @@
           <h3>Files shared with me</h3>
 
           {{#if sharesWithMe}}
-          <table class="table table-striped table-responsive-sm table-sm">
-            <tr>
-              <th scope="col">title</th>
-              <th scope="col">created</th>
-              <th scope="col">shared by</th>
-              <th scope="col">accepted</th>
-            </tr>
-            {{#each sharesWithMe}}
-            <tr>
-              <td><a href="{{url}}" target="_blank">{{title}}</a></td>
-              <td>{{created}}</td>
-              <td>@{{from}}</td>
-              <td>{{claimed}}</td>
-            </tr>
-            {{/each}}
-          </table>
+          <div class="container">
+            <table class="table table-striped table-responsive-sm table-sm">
+              <tr>
+                <th scope="col">title</th>
+                <th scope="col">created</th>
+                <th scope="col">shared by</th>
+                <th scope="col">accepted</th>
+              </tr>
+              {{#each sharesWithMe}}
+              <tr>
+                <td><a href="{{url}}" target="_blank">{{title}}</a></td>
+                <td>{{created}}</td>
+                <td>@{{from}}</td>
+                <td>{{claimed}}</td>
+              </tr>
+              {{/each}}
+            </table>
+          </div>
           {{else}}
           (none)
           {{/if}}
@@ -48,29 +50,31 @@
         <div class="col text-center">
           <h3>Files I've shared</h3>
           {{#if sharesByMe}}
-          <table class="table table-striped table-responsive-sm table-sm">
-            <tr>
-              <th scope="col">title</th>
-              <th scope="col">created</th>
-              <th scope="col">expires</th>
-              <th scope="col">shared to</th>
-              <th scope="col">claimed</th>
-              <th scope="col">claimed by</th>
-            </tr>
-            {{#each sharesByMe}}
-            <tr>
-              <td>
-                <strong>{{title}}</strong>
-                <small>[<a class="copy_link" href="#" data-url="{{url}}">copy</a>]</small>
-              </td>
-              <td>{{created}}</td>
-              <td>{{#if expires}}{{expires}}{{else}}(never){{/if}}</td>
-              <td>{{#if to}}@{{to}}{{else}}(anyone){{/if}}</td>
-              <td>{{claimed}}</td>
-              <td>{{#if claimed_by}}@{{claimed_by}}{{/if}}</td>
-            </tr>
-            {{/each}}
-          </table>
+          <div class="container">
+            <table class="table table-striped table-responsive-sm table-sm">
+              <tr>
+                <th scope="col">title</th>
+                <th scope="col">created</th>
+                <th scope="col">expires</th>
+                <th scope="col">shared to</th>
+                <th scope="col">claimed</th>
+                <th scope="col">claimed by</th>
+              </tr>
+              {{#each sharesByMe}}
+              <tr>
+                <td>
+                  <strong>{{title}}</strong>
+                  <small>[<a class="copy_link" href="#" data-url="{{url}}">copy</a>]</small>
+                </td>
+                <td>{{created}}</td>
+                <td>{{#if expires}}{{expires}}{{else}}(never){{/if}}</td>
+                <td>{{#if to}}@{{to}}{{else}}(anyone){{/if}}</td>
+                <td>{{claimed}}</td>
+                <td>{{#if claimed_by}}@{{claimed_by}}{{/if}}</td>
+              </tr>
+              {{/each}}
+            </table>
+          </div>
           {{else}}
           <p>
             (none)


### PR DESCRIPTION
Resolves #7 

PR #8 fixed the issue with tables not scrolling on mobile browsers, but it made them too wide on desktop. This fix gives us the best of both worlds by wrapping tables in its own `container` instead of just the parent's `container-fluid`.