### PR TITLE
fix: POST assertion/options allows existing session

### DIFF
--- a/src/routes/fido2/assertion.test.ts
+++ b/src/routes/fido2/assertion.test.ts
@@ -164,23 +164,6 @@ test("routes/fido2/assertion", async (t) => {
   });
 
   t.test("POST /options", async (t) => {
-    t.test(
-      "if active user session, renders JSON with expected user error",
-      async (t) => {
-        const { app } = createAssertionTestExpressApp(t, { withAuth: true });
-        const response = await performOptionsPostRequest(app).send({
-          username: "bob",
-        });
-
-        verifyUserErrorFido2ServerResponse(
-          t,
-          response,
-          StatusCodes.FORBIDDEN,
-          "User is already signed in"
-        );
-      }
-    );
-
     t.test("if username is passed in the request", async (t) => {
       t.test("fetches user with trimmed username", async (t) => {
         fetchUserByNameStub.resolves({});
@@ -396,25 +379,47 @@ test("routes/fido2/assertion", async (t) => {
       });
     });
 
-    t.test(
-      "if successful, renders JSON with expected options data",
-      async (t) => {
-        fetchUserByNameStub.resolves({});
-        fetchCredentialsByUsernameStub.resolves([testCredential1()]);
-        generateAuthenticationOptionsStub.returns({
-          challenge: "CHALLENGE!",
-        });
+    t.test("when successful", async (t) => {
+      t.test(
+        "if no existing session, renders JSON with expected options data",
+        async (t) => {
+          fetchUserByNameStub.resolves({});
+          fetchCredentialsByUsernameStub.resolves([testCredential1()]);
+          generateAuthenticationOptionsStub.returns({
+            challenge: "CHALLENGE!",
+          });
 
-        const { app } = createAssertionTestExpressApp(t);
-        const response = await performOptionsPostRequest(app).send({
-          username: "bob",
-        });
+          const { app } = createAssertionTestExpressApp(t);
+          const response = await performOptionsPostRequest(app).send({
+            username: "bob",
+          });
 
-        verifyFido2SuccessResponse(t, response, {
-          challenge: "CHALLENGE!",
-        });
-      }
-    );
+          verifyFido2SuccessResponse(t, response, {
+            challenge: "CHALLENGE!",
+          });
+        }
+      );
+
+      t.test(
+        "if existing session, renders JSON with expected options data",
+        async (t) => {
+          fetchUserByNameStub.resolves({});
+          fetchCredentialsByUsernameStub.resolves([testCredential1()]);
+          generateAuthenticationOptionsStub.returns({
+            challenge: "CHALLENGE!",
+          });
+
+          const { app } = createAssertionTestExpressApp(t, { withAuth: true });
+          const response = await performOptionsPostRequest(app).send({
+            username: "bob",
+          });
+
+          verifyFido2SuccessResponse(t, response, {
+            challenge: "CHALLENGE!",
+          });
+        }
+      );
+    });
   });
 
   t.test("POST /result", async (t) => {

--- a/src/routes/fido2/assertion.ts
+++ b/src/routes/fido2/assertion.ts
@@ -17,7 +17,7 @@ import { RegisteredAuthenticator, User } from "../../types/entity";
 import { AuthenticatedRequest } from "../../types/express";
 import { beginSignIn, getAuthentication, signIn } from "../../utils/auth";
 import { baseUrl, rpID } from "../../utils/config";
-import { BadRequestError, ForbiddenError } from "../../utils/error";
+import { BadRequestError } from "../../utils/error";
 import { logger } from "../../utils/logger";
 
 const router = Router();
@@ -34,11 +34,6 @@ router.post(
   "/options",
   json(),
   async (req: AuthenticatedRequest, res: Response) => {
-    // ensure there isn't an active user session
-    if (req.user) {
-      throw ForbiddenError("User is already signed in");
-    }
-
     // validate request
     let { username, userVerification } = req.body;
     username = username ? username.trim() : "";


### PR DESCRIPTION
The POST `/fido2/assertion/options` endpoint used to return a 403 Forbidden error if a session already existed. This change allows there to be an existing session. There's really no reason a user cannot navigate back to the `/login` page and sign in as someone else without having to sign out first.

Fixes #19 