### PR TITLE
fix: content security policy

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -70,14 +70,29 @@ test("app", async (t) => {
     t.equal(expressApp.disable.getCalls()[0].firstArg, "x-powered-by");
   });
 
-  t.test("uses helmet middleware", async (t) => {
-    importModule(t);
+  t.test(
+    "uses helmet middleware and configures a compatible content security policy",
+    async (t) => {
+      importModule(t);
 
-    t.ok(helmetFake.called);
+      t.ok(helmetFake.called);
+      t.same(helmetFake.firstCall.firstArg, {
+        contentSecurityPolicy: {
+          directives: {
+            "script-src": [
+              "'unsafe-inline'",
+              "'self'",
+              "cdn.jsdelivr.net",
+              "unpkg.com",
+            ],
+          },
+        },
+      });
 
-    t.ok(expressApp.use.called);
-    t.equal(expressApp.use.getCalls()[0].firstArg, helmetMiddleware);
-  });
+      t.ok(expressApp.use.called);
+      t.equal(expressApp.use.getCalls()[0].firstArg, helmetMiddleware);
+    }
+  );
 
   t.test("uses express-pino-logger middleware", async (t) => {
     importModule(t);

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,7 +14,20 @@ const app: Express = express();
 app.disable("x-powered-by");
 
 // App-level middleware
-app.use(helmet());
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        "script-src": [
+          "'unsafe-inline'",
+          "'self'",
+          "cdn.jsdelivr.net",
+          "unpkg.com",
+        ],
+      },
+    },
+  })
+);
 app.use(pinoHttp({ logger }));
 
 app.use(express.static("public"));

--- a/views/accept_invite.handlebars
+++ b/views/accept_invite.handlebars
@@ -1,6 +1,6 @@
 {{#> main_layout}}
   {{#*inline "head_scripts"}}
-    <script src="https://cdn.jsdelivr.net/npm/js-base64@3.7.5/base64.min.js"></script>
+    {{> base64_scripts }}
     {{> passkey_scripts }}
   {{/inline}}
 

--- a/views/accept_share.handlebars
+++ b/views/accept_share.handlebars
@@ -1,6 +1,6 @@
 {{#> main_layout}}
   {{#*inline "head_scripts"}}
-    <script src="https://cdn.jsdelivr.net/npm/js-base64@3.7.5/base64.min.js"></script>
+    {{> base64_scripts }}
     {{> passkey_scripts }}
   {{/inline}}
 

--- a/views/login.handlebars
+++ b/views/login.handlebars
@@ -1,6 +1,6 @@
 {{#> main_layout}}
   {{#*inline "head_scripts"}}
-    <script src="https://cdn.jsdelivr.net/npm/js-base64@3.7.5/base64.min.js"></script>
+    {{> base64_scripts }}
     {{> passkey_scripts }}
   {{/inline}}
 

--- a/views/partials/base64_scripts.handlebars
+++ b/views/partials/base64_scripts.handlebars
@@ -1,0 +1,5 @@
+<script 
+  src="https://cdn.jsdelivr.net/npm/js-base64@3.7.5/base64.min.js"
+  integrity="sha384-xRyCYXZrqV+SmMasrW9tuHoKclrgxrlBZ9fFexs5HDJsnSk2+pzmrJp2IaW12bQs"
+  crossorigin="anonymous"
+></script>

--- a/views/profile.handlebars
+++ b/views/profile.handlebars
@@ -1,6 +1,6 @@
 {{#> main_layout}}
   {{#*inline "head_scripts"}}
-    <script src="https://cdn.jsdelivr.net/npm/js-base64@3.7.5/base64.min.js"></script>
+    {{> base64_scripts }}
     {{> passkey_scripts }}
   {{/inline}}
 

--- a/views/register.handlebars
+++ b/views/register.handlebars
@@ -1,6 +1,6 @@
 {{#> main_layout}}
   {{#*inline "head_scripts"}}
-    <script src="https://cdn.jsdelivr.net/npm/js-base64@3.7.5/base64.min.js"></script>
+    {{> base64_scripts }}
     {{> passkey_scripts }}
   {{/inline}}
 


### PR DESCRIPTION
This fix is required due to the enabling of the [helmet](https://www.npmjs.com/package/helmet) package which, among other things, locks down the use of client-side scripts without their explicit definition in a `Content-Security-Policy`. This policy blocks the potential use of XSS attacks.

Updates #40